### PR TITLE
Removed a workaround to handle no content response in organization destroy

### DIFF
--- a/command/organizations/destroy_command.go
+++ b/command/organizations/destroy_command.go
@@ -1,7 +1,6 @@
 package organizations
 
 import (
-	"encoding/json"
 	"github.com/jmatsu/dpg/api"
 	"github.com/jmatsu/dpg/api/request/organizations/destroy"
 	"github.com/jmatsu/dpg/command"
@@ -54,11 +53,6 @@ func (cmd destroyCommand) VerifyInput() error {
 
 func (cmd destroyCommand) Run(authorization *api.Authorization) (string, error) {
 	if bytes, err := cmd.endpoint.DeleteRequest(*authorization, *cmd.requestBody); err != nil {
-		if _, ok := err.(*json.SyntaxError); ok {
-			// no-content
-			return "", nil
-		}
-
 		return "", err
 	} else {
 		return string(bytes), nil


### PR DESCRIPTION
The api has been fixed.