### PR TITLE
Fix main build error

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ SUPPORT:
 	app.Usage = "Unofficial DeployGate API Client CLI"
 	app.Description = "dpg is an unofficial command line tool to access DeployGate API."
 	app.Version = version.Version
-	app.EnableShellCompletion = true
+	app.EnableBashCompletion = true
 	app.Commands = []*cli.Command{
 		{
 			Name:  "app",

--- a/main.go
+++ b/main.go
@@ -33,8 +33,6 @@ func main() {
 		logrus.SetLevel(logrus.ErrorLevel)
 	}
 
-	cli.InitCompletionFlag.Hidden = true
-
 	cli.AppHelpTemplate = fmt.Sprintf(`%s
 COMPLETION:
 	dpg --init-completion <bash|zsh>


### PR DESCRIPTION
## Overview
Run go build, it will output an error:
```
./main.go:36:2: undefined: cli.InitCompletionFlag
./main.go:58:5: app.EnableShellCompletion undefined (type *cli.App has no field or method EnableShellCompletion)
```

